### PR TITLE
Fix select typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Zendesk is expecting a `departments.select` variable, but we were getting from the schema `departments.selected`.
 
 ## [1.2.1] - 2019-11-19
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -91,7 +91,7 @@
                       "type": "string"
                     }
                   },
-                  "selected": {
+                  "select": {
                     "title": "Select",
                     "description": "Sets the visitor’s default department for the current session",
                     "type": "string"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix typo of `departments.select` setting.

#### How should this be manually tested?

1. Go to the [workspace](https://selectprop--gympassus.myvtex.com/)
2. Open the console
3. Type `window.zESettings.departments.select`
4. You should see a department selected

#### Screenshots or example usage

#### Types of changes

* [X] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
