### PR TITLE
Add a fake chat button to defer script loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Feat
+- Add a fake chat button to defer the loading of Zendesk's script.
 
 ## [1.2.7] - 2020-08-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Feat
-- Add a fake chat button to defer the loading of Zendesk's script.
+### Added
+- Fake chat button to defer the loading of Zendesk's script.
 
 ## [1.2.7] - 2020-08-19
 ### Fixed

--- a/pixel/head.html
+++ b/pixel/head.html
@@ -1,78 +1,204 @@
-<script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key={{settings.accountKey}}"></script>
 <script>
-  window.addEventListener('load', function() {
-    var urlPath = document.URL
-    var titlePathPreffix = window.decodeURIComponent('{{ settings.titlePreffix }}')
-    var titleEl = document.querySelector('head > title')
-    var titlePath = titlePathPreffix + (titleEl ? titleEl.innerText : '')
-    var curLocale = document.querySelector('html').lang
+  (function () {
+    var btn = document.createElement("button");
 
-    function parseValuesToInt(arr = []) {
-      return arr.map(function(value) {
-        var intValue = parseInt(value)
+    function parseValuesToInt(arr) {
+      if (!arr) return [];
+
+      return arr.map(function (value) {
+        var intValue = parseInt(value);
+
         if (!isNaN(intValue)) {
-          return intValue
+          return intValue;
         }
-        return value
-      })
+
+        return value;
+      });
     }
 
-    zE(function () {
-      $zopim(function() {
-        zE('webWidget', 'setLocale', curLocale)
-        $zopim.livechat.sendVisitorPath({
-          url: urlPath,
-          title: titlePath
-        })
-      })
+    function getIn(path, obj) {
+      var value = obj;
 
-      if (window.__RENDER_8_SESSION__ && window.__RENDER_8_SESSION__.sessionPromise) {
-        window.__RENDER_8_SESSION__.sessionPromise.then(function (session) {
-          var userEmail = window.R.path(['response', 'namespaces', 'profile', 'email', 'value'], session) || ''
-          var firstName = window.R.path(['response', 'namespaces', 'profile', 'firstName', 'value'], session) || ''
-          var lastName = window.R.path(['response', 'namespaces', 'profile', 'lastName', 'value'], session) || ''
-          var userName = (firstName ? firstName + ' ' : '') + lastName
-          if (userEmail || userName) {
-            zE.identify({
-              name: userName,
-              email: userEmail
-            })
+      if (!value) return value;
+
+      for (var i = 0; i < path.length; i++) {
+        if (!(path[i] in value)) {
+          return undefined;
+        }
+        value = value[path[i]];
+      }
+
+      return value;
+    }
+
+    function configureSnippetForVTEX() {
+      var urlPath = document.URL;
+      var titlePathPreffix = decodeURIComponent("{{ settings.titlePreffix }}");
+      var titleEl = document.querySelector("head > title");
+      var titlePath = titlePathPreffix + (titleEl ? titleEl.innerText : "");
+      var curLocale = document.querySelector("html").lang;
+
+      zE(function () {
+        $zopim(function () {
+          zE("webWidget", "setLocale", curLocale);
+          $zopim.livechat.sendVisitorPath({ url: urlPath, title: titlePath });
+        });
+
+        if (
+          window.__RENDER_8_SESSION__ &&
+          window.__RENDER_8_SESSION__.sessionPromise
+        ) {
+          window.__RENDER_8_SESSION__.sessionPromise.then(function (session) {
+            var userEmail =
+              getIn(
+                ["response", "namespaces", "profile", "email", "value"],
+                session
+              ) || "";
+            var firstName =
+              getIn(
+                ["response", "namespaces", "profile", "firstName", "value"],
+                session
+              ) || "";
+            var lastName =
+              getIn(
+                ["response", "namespaces", "profile", "lastName", "value"],
+                session
+              ) || "";
+
+            var userName = (firstName ? firstName + " " : "") + lastName;
+
+            if (userEmail || userName) {
+              zE.identify({ name: userName, email: userEmail });
+            }
+          });
+        }
+      });
+
+      var analytics = decodeURIComponent("{{ settings.analytics }}") === "true";
+      window.zESettings = window.zESettings || {};
+      window.zESettings.analytics = analytics;
+
+      try {
+        webWidget = JSON.parse(decodeURI("{{ settings.webWidget }}"));
+      } catch (e) {
+        return;
+      }
+
+      var helpCenterSuppress = webWidget.helpCenter.suppress;
+      var departments = webWidget.chat.departments;
+      var color = webWidget.color;
+      var enabled = parseValuesToInt(departments.enabled);
+      var select = isNaN(parseInt(departments.select))
+        ? departments.select
+        : parseInt(departments.select);
+      var tags = departments.tags;
+
+      window.zESettings.webWidget = {
+        color: {
+          theme: color.theme,
+        },
+        helpCenter: {
+          suppress: helpCenterSuppress,
+        },
+        chat: {
+          departments: {
+            enabled: enabled,
+            select: select,
+            tags: tags,
+          },
+        },
+      };
+    }
+
+    function addZDSnippet() {
+      var script = document.createElement("script");
+
+      btn.disabled = true;
+
+      script.id = "ze-snippet";
+      script.async = "async";
+      script.src =
+        "https://static.zdassets.com/ekr/snippet.js?key={{settings.accountKey}}";
+      script.onload = function () {
+        var intervalId = setInterval(function () {
+          if ("zE" in window && "activate" in zE) {
+            clearInterval(intervalId);
+
+            zE("webWidget:on", "chat:end", function () {
+              localStorage.setItem("zdChatOpen", false);
+            });
+
+            configureSnippetForVTEX();
+
+            zE.activate();
+
+            document.body.removeChild(btn);
           }
-        })
+        }, 400);
+      };
 
-      }
-    })
-
-    var analytics = window.decodeURIComponent('{{ settings.analytics }}') === 'true'
-    window.zESettings = window.zESettings || {}
-    window.zESettings.analytics = analytics
-
-    try {
-      webWidget = JSON.parse(window.decodeURIComponent('{{ settings.webWidget }}'))
-    } catch(e) {
-      return
+      document.head.appendChild(script);
     }
 
-    var helpCenterSuppress =  webWidget.helpCenter.suppress
-    var departments = webWidget.chat.departments
-    var color = webWidget.color
-    var enabled = parseValuesToInt(departments.enabled)
-    var select = isNaN(parseInt(departments.select)) ? departments.select : parseInt(departments.select)
-    var tags = departments.tags
-    window.zESettings.webWidget = {
-      color: {
-        theme: color.theme
-      },
-      helpCenter: {
-        suppress: helpCenterSuppress
-      },
-      chat: {
-        departments: {
-          enabled: enabled,
-          select: select,
-          tags: tags
+    function shouldOpenChat() {
+      var zdStore = JSON.parse(localStorage.getItem("ZD-store"));
+
+      if (zdStore) {
+        return zdStore.widgetShown;
+      }
+
+      return localStorage.getItem("zdChatOpen") === "true";
+    }
+
+    window.addEventListener("DOMContentLoaded", function () {
+      if (shouldOpenChat()) {
+        addZDSnippet();
+      } else {
+        btn.id = "zendesk-fake-btn";
+        btn.innerHTML =
+          '<svg id="zendesk-fake-icon" x="0" y="0" viewBox="0 0 15 16" xml:space="preserve" aria-hidden="true"><path d="M1.3,16c-0.7,0-1.1-0.3-1.2-0.8c-0.3-0.8,0.5-1.3,0.8-1.5c0.6-0.4,0.9-0.7,1-1c0-0.2-0.1-0.4-0.3-0.7c0,0,0-0.1-0.1-0.1 C0.5,10.6,0,9,0,7.4C0,3.3,3.4,0,7.5,0C11.6,0,15,3.3,15,7.4s-3.4,7.4-7.5,7.4c-0.5,0-1-0.1-1.5-0.2C3.4,15.9,1.5,16,1.5,16 C1.4,16,1.4,16,1.3,16z M3.3,10.9c0.5,0.7,0.7,1.5,0.6,2.2c0,0.1-0.1,0.3-0.1,0.4c0.5-0.2,1-0.4,1.6-0.7c0.2-0.1,0.4-0.2,0.6-0.1 c0,0,0.1,0,0.1,0c0.4,0.1,0.9,0.2,1.4,0.2c3,0,5.5-2.4,5.5-5.4S10.5,2,7.5,2C4.5,2,2,4.4,2,7.4c0,1.2,0.4,2.4,1.2,3.3 C3.2,10.8,3.3,10.8,3.3,10.9z"></path></svg><span>Chat</span>';
+
+        btn.className =
+          "b br-pill pointer bg-base--inverted white-90 flex items-center justify-center";
+
+        btn.addEventListener("click", function () {
+          localStorage.setItem("zdChatOpen", true);
+          addZDSnippet();
+        });
+
+        document.body.appendChild(btn);
+      }
+    });
+
+    window.addEventListener(
+      "visibilitychange",
+      function () {
+        if (document.visibilityState === "hidden") {
+          localStorage.setItem("zdChatOpen", false);
         }
-      }
-    }
-})
+      },
+      false
+    );
+  })();
 </script>
+
+<style>
+  #zendesk-fake-icon {
+    padding-right: 0.57143rem;
+    fill: currentColor;
+    width: 1.42rem;
+    height: 1.42rem;
+  }
+
+  #zendesk-fake-btn {
+    position: fixed;
+    right: 20px;
+    bottom: 10px;
+    width: 109px;
+    height: 50px;
+    opacity: 1;
+    border: 0px;
+    z-index: 999998;
+    -webkit-appearance: none;
+  }
+</style>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Zendesk's script loads more than 2mb of data just for the chat. This PR creates a fake chat button that defers the loading of zendesk's script to after a user clicks the chat button. It's persisted between pages.

#### How should this be manually tested?

Compare both:

https://storetheme.vtex.com/?workspace=zendeskunmodified
https://storetheme.vtex.com/?workspace=kiwi

Pagespeed scores:
https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fstoretheme.vtex.com%2F%3Fworkspace%3Dzendeskunmodified: 11

https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fstoretheme.vtex.com%2F%3Fworkspace%3Dkiwi: 33


#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [x] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.


![](https://media.giphy.com/media/14mEmhgtllosmc/giphy.gif)