### PR TITLE
Add safe-guard for deprecated `color` settings object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add safe-guard for deprecated `color` settings object.
 
 ## [1.4.0] - 2020-10-29
 ### Added

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -70,12 +70,12 @@ function bootstrap() {
 
   const IS_MOBILE = window.__RUNTIME__.hints.mobile
 
-  const btnLabel = widgetSettings.theme.launcherLabel || 'Chat'
-  const btnBgColor = widgetSettings.theme.launcherColor
-  const btnTextColor = widgetSettings.theme.launcherTextColor
-  const btnPosition = widgetSettings.theme.launcherPosition || 'right'
-  const chatTheme = widgetSettings.theme.theme
-  const widgetZindex = widgetSettings.theme.widgetZindex || '999998'
+  const chatTheme = widgetSettings.theme?.theme || widgetSettings.color?.theme
+  const btnLabel = widgetSettings.theme?.launcherLabel || 'Chat'
+  const btnBgColor = widgetSettings.theme?.launcherColor || chatTheme
+  const btnTextColor = widgetSettings.theme?.launcherTextColor
+  const btnPosition = widgetSettings.theme?.launcherPosition || 'right'
+  const widgetZindex = widgetSettings.theme?.widgetZindex || '999998'
 
   function configureSnippetForVTEX() {
     window.zESettings = window.zESettings || {}

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -15,6 +15,10 @@ declare global {
 
     __zendeskPixel: {
       widget: {
+        // @deprecated. Use `theme`
+        color?: {
+          theme: string
+        }
         theme: {
           launcherLabel: string
           launcherColor: string


### PR DESCRIPTION
#### What is the purpose of this pull request?

On the previous release, we changed the `color` settings property to `theme` and forgot to add safe-guards for the old behavior. This PR fixes this and tries to guess the chat button background by using the defined `theme` color if an explicit `button background` is not defined.

#### How should this be manually tested?

Compare:
https://kiwi--dzarm.myvtex.com/
https://dzarm.myvtex.com/

With the console open

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
